### PR TITLE
Parser resilience to non string inputs

### DIFF
--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -624,24 +624,25 @@ class Match(ParsingExpression):
 
         # Skip whitespaces and parse comments if we are not
         # in the lexical rule
-        if not parser.in_lex_rule:
-            parser._skip_ws()
-            if parser.comments_model and not parser.in_parse_comment:
-                parser.in_parse_comment = True
-                try:
-                    while True:
-                        parser.comments.append(
-                            parser.comments_model.parse(parser))
-                        parser._skip_ws()
-                except NoMatch:
-                    # NoMatch in comment matching is perfectly
-                    # legal and no action should be taken.
-                    pass
+        try:
+            if not parser.in_lex_rule:
+                parser._skip_ws()
+                if parser.comments_model and not parser.in_parse_comment:
+                    parser.in_parse_comment = True
+                    try:
+                        while True:
+                            parser.comments.append(
+                                parser.comments_model.parse(parser))
+                            parser._skip_ws()
+                    except NoMatch:
+                        # NoMatch in comment matching is perfectly
+                        # legal and no action should be taken.
+                        pass
 
-                finally:
-                    parser.in_parse_comment = False
-
-        parser.in_parse_intro = False
+                    finally:
+                        parser.in_parse_comment = False
+        finally:
+            parser.in_parse_intro = False
 
     def parse(self, parser):
         if parser.debug:

--- a/tests/unit/test_parser_resilience.py
+++ b/tests/unit/test_parser_resilience.py
@@ -1,0 +1,12 @@
+# coding=utf-8
+from __future__ import unicode_literals, absolute_import
+from arpeggio import ParserPython, EOF
+import pytest
+
+
+def test_parser_resilience():
+    """Tests that arpeggio parsers recover successfully from failure."""
+    parser = ParserPython(('findme', EOF))
+    with pytest.raises(TypeError):
+        parser.parse(map)
+    assert parser.parse('  findme  ') is not None


### PR DESCRIPTION
Arpeggio parsers do not recover properly if we ask them to parse a non-string object, leading to failure to later accept valid strings if they contain spaces. This PR includes a test showing the problem and a solution. Let me know if the test should go somewhere else.

Thanks a lot for arpeggio Igor, it is neat and I'm [having fun using it](https://github.com/sdvillal/whatami/blob/master/whatami/parsers.py). This has been the only real problem I have had until now. Until I realised that my unit tests were failing depending on their order of execution, I spent an unreasonable amount of perplexity while git-bisecting on the chase for errors in my grammar and wondering why the same tests passed on python 3 but not on python 2.