### PR TITLE
RegExMatch support for multiline pattern + unit test

### DIFF
--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -781,19 +781,23 @@ class RegExMatch(Match):
             Default is None to support propagation from global parser setting.
         multiline(bool): allow regex to works on multiple lines (re.DOTALL flag)
         str_repr(str): A string that is used to represent this regex.
+        re_flags: flags parameter for re.compile if neither ignore_case
+            or multiple are set.
 
     '''
     def __init__(self, to_match, rule_name='', root=False, ignore_case=None,
-                 multiline=False, str_repr=None):
+                 multiline=False, str_repr=None, re_flags=re.MULTILINE):
         super(RegExMatch, self).__init__(rule_name, root)
         self.to_match_regex = to_match
         self.ignore_case = ignore_case
         self.multiline = multiline
+        implicit_flag = any((self.ignore_case, self.multiline, to_match is None))
+        self.flags = re.MULTILINE if implicit_flag else re_flags
 
         self.to_match = str_repr if str_repr is not None else to_match
 
     def compile(self):
-        flags = re.MULTILINE
+        flags = self.flags
         if self.multiline:
             flags |= re.DOTALL
         if self.ignore_case:

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -779,29 +779,33 @@ class RegExMatch(Match):
             It will be used to create regular expression using re.compile.
         ignore_case(bool): If case insensitive match is needed.
             Default is None to support propagation from global parser setting.
-        multiline(bool): allow regex to works on multiple lines (re.DOTALL flag)
+        multiline(bool): allow regex to works on multiple lines (re.DOTALL flag).
+            Default is None to support propagation from global parser setting.
         str_repr(str): A string that is used to represent this regex.
         re_flags: flags parameter for re.compile if neither ignore_case
             or multiple are set.
 
     '''
     def __init__(self, to_match, rule_name='', root=False, ignore_case=None,
-                 multiline=False, str_repr=None, re_flags=re.MULTILINE):
+                 multiline=None, str_repr=None, re_flags=re.MULTILINE):
         super(RegExMatch, self).__init__(rule_name, root)
         self.to_match_regex = to_match
         self.ignore_case = ignore_case
         self.multiline = multiline
-        implicit_flag = any((self.ignore_case, self.multiline, to_match is None))
-        self.flags = re.MULTILINE if implicit_flag else re_flags
+        self.explicit_flags = re_flags
 
         self.to_match = str_repr if str_repr is not None else to_match
 
     def compile(self):
-        flags = self.flags
-        if self.multiline:
+        flags = self.explicit_flags
+        if self.multiline is True:
             flags |= re.DOTALL
-        if self.ignore_case:
+        if self.multiline is False and flags & re.DOTALL:
+            flags -= re.DOTALL
+        if self.ignore_case is True:
             flags |= re.IGNORECASE
+        if self.ignore_case is False and flags & re.IGNORECASE:
+            flags -= re.IGNORECASE
         self.regex = re.compile(self.to_match_regex, flags)
 
     def __str__(self):

--- a/arpeggio/__init__.py
+++ b/arpeggio/__init__.py
@@ -779,19 +779,23 @@ class RegExMatch(Match):
             It will be used to create regular expression using re.compile.
         ignore_case(bool): If case insensitive match is needed.
             Default is None to support propagation from global parser setting.
+        multiline(bool): allow regex to works on multiple lines (re.DOTALL flag)
         str_repr(str): A string that is used to represent this regex.
 
     '''
     def __init__(self, to_match, rule_name='', root=False, ignore_case=None,
-                 str_repr=None):
+                 multiline=False, str_repr=None):
         super(RegExMatch, self).__init__(rule_name, root)
         self.to_match_regex = to_match
         self.ignore_case = ignore_case
+        self.multiline = multiline
 
         self.to_match = str_repr if str_repr is not None else to_match
 
     def compile(self):
         flags = re.MULTILINE
+        if self.multiline:
+            flags |= re.DOTALL
         if self.ignore_case:
             flags |= re.IGNORECASE
         self.regex = re.compile(self.to_match_regex, flags)

--- a/tests/unit/test_flags.py
+++ b/tests/unit/test_flags.py
@@ -8,6 +8,7 @@
 #######################################################################
 
 from __future__ import unicode_literals
+import re
 import pytest
 
 # Grammar
@@ -16,11 +17,12 @@ from arpeggio import RegExMatch as _
 from arpeggio import NoMatch
 
 
-def foo():    return 'r', bar, Optional(qux), baz, Optional(buz), EOF
+def foo():      return 'r', bar, Optional(qux), baz, Optional(ham), Optional(buz), EOF
 def bar():      return 'BAR'
 def baz():      return _(r'1\w+')
 def buz():      return _(r'Aba*', ignore_case=True)
 def qux():      return _(r'/\*.*\*/', multiline=True)
+def ham():      return _(r'/\*.*\*/', re_flags=re.DOTALL)  # equivalent to qux
 
 
 @pytest.fixture
@@ -55,5 +57,11 @@ def test_flags_override(parser_nonci):
 
 def test_multiline_comment(parser_nonci):
     input_str = "r BAR /*1baz\nabaaaaAAaaa\n*/1baz"
+    parse_tree = parser_nonci.parse(input_str)
+    assert parse_tree is not None
+
+
+def test_multiline_comment_by_re_flags(parser_nonci):
+    input_str = "r BAR 1baz/*this\nis\nnot\nparsed*/"
     parse_tree = parser_nonci.parse(input_str)
     assert parse_tree is not None

--- a/tests/unit/test_flags.py
+++ b/tests/unit/test_flags.py
@@ -16,10 +16,11 @@ from arpeggio import RegExMatch as _
 from arpeggio import NoMatch
 
 
-def foo():    return 'r', bar, baz, Optional(buz), EOF
+def foo():    return 'r', bar, Optional(qux), baz, Optional(buz), EOF
 def bar():      return 'BAR'
 def baz():      return _(r'1\w+')
 def buz():      return _(r'Aba*', ignore_case=True)
+def qux():      return _(r'/\*.*\*/', multiline=True)
 
 
 @pytest.fixture
@@ -48,5 +49,11 @@ def test_flags_override(parser_nonci):
     # Parser is not case insensitive
     # But the buz match is.
     input_str = "r BAR 1baz abaaaaAAaaa"
+    parse_tree = parser_nonci.parse(input_str)
+    assert parse_tree is not None
+
+
+def test_multiline_comment(parser_nonci):
+    input_str = "r BAR /*1baz\nabaaaaAAaaa\n*/1baz"
     parse_tree = parser_nonci.parse(input_str)
     assert parse_tree is not None


### PR DESCRIPTION
This PR aims to provide multiline (comment) support.

This is performed by providing another switch to RegExMatch constructor, `multiline`.
Purpose of `multiline` is to abstract the need of multiline regexes, made possible by the `re.DOTALL` flag.

Please consider adding a more generalist `flag` parameter waiting for arbitrary re flags,
allowing further customization of the RegExMatch object.